### PR TITLE
Changed generic string to date

### DIFF
--- a/Technology Description.md
+++ b/Technology Description.md
@@ -518,7 +518,7 @@ The API is only accessible by the HIS
 ```
 {
   "otp": string,
-  "symptoms_started_on": string
+  "symptoms_started_on": date
 }
 ```
 


### PR DESCRIPTION
`symptoms_started_on` is later referred as `date`

It would be awesome if you could publish the endpoints documentation following the [OpenAPI](http://spec.openapis.org/oas/v3.0.3) specifications with an accompanying YAML or JSON file.

There are a few references like `ObjectID` or `date` that are not JSON primitives and a more precise specification could help to understand date format ([ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html)?)